### PR TITLE
Update http dependency to > 4.3

### DIFF
--- a/googlemaps-services.gemspec
+++ b/googlemaps-services.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'nokogiri', '~> 1.7', '>= 1.7.1'
-  spec.add_runtime_dependency 'http', '~> 3.0', '>= 3.0.0'
-  spec.add_development_dependency 'bundler', '~> 1.14'
+  spec.add_runtime_dependency 'http', '~> 4.3'
+  spec.add_development_dependency 'bundler', '~> 2.2'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.5'
 end


### PR DESCRIPTION
We are using this gem and have identified an intermittent fault after upgrading to Ruby 2.7. The `http` gem is pinned to version 3 but Ruby 2.7 support was added with version 4.3.0.

I have a test to demonstrate:

```ruby
require 'googlemaps/services/client'

include GoogleMaps::Services

key = '<add your API key here>'
origin = 'SW1A 1AA'
destination = 'SW1A 2AA'

c = GoogleClient.new(key: key, response_format: :json)
params = { 'origin' => origin, 'destination' => destination, 'region' => 'uk', 'alternatives' => true }

10.times do |i|
  response = c.request(url: '/maps/api/directions/json', params: params)
end
```

At some point you get a `can't modify frozen String: "" (FrozenError)` error at `http-3.3.0/lib/http/response/body.rb:52`. This is resolved with version 4.3 or later of `http`.